### PR TITLE
fix(): add missing default exports in os

### DIFF
--- a/polyfills/os.js
+++ b/polyfills/os.js
@@ -97,6 +97,8 @@ export var tmpdir = tmpDir;
 export var EOL = '\n';
 export default {
   EOL: EOL,
+  arch: arch,
+  platform: platform,
   tmpdir: tmpdir,
   tmpDir: tmpDir,
   networkInterfaces:networkInterfaces,


### PR DESCRIPTION
Adding missing default exports, assuming they were just left out by accident.