### PR TITLE
fixes import and requires with a trailing Slash (/)

### DIFF
--- a/src/modules.ts
+++ b/src/modules.ts
@@ -62,7 +62,7 @@ export function builtinsResolver(opts: NodePolyfillsOptions) {
 
   return (importee: string) => {
     if (importee && importee.slice(-1) === '/') {
-      importee === importee.slice(0, -1);
+      importee = importee.slice(0, -1);
     }
     if (libs.has(importee)) {
       return {id: libs.get(importee), moduleSideEffects: false};

--- a/test/examples/buffer.js
+++ b/test/examples/buffer.js
@@ -1,0 +1,7 @@
+import { Buffer } from 'buffer/'
+
+if (Buffer.from('abc').length == 3) {
+    done();
+} else {
+    done(new Error('Loading Buffer with a trailing /'));
+}

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,8 @@ const files = [
   'string-decoder.js',
   'zlib.js',
   'domain.js',
-  'crypto.js'
+  'crypto.js',
+  'buffer.js'
 ];
 
 describe('rollup-plugin-node-polyfills', () => {


### PR DESCRIPTION
This PR fixes the [issue](https://github.com/ionic-team/rollup-plugin-node-polyfills/issues/3) with a trailing slashes in the end of import or require statements