### PR TITLE
Add `off` method for `events` polyfill

### DIFF
--- a/polyfills/events.js
+++ b/polyfills/events.js
@@ -353,6 +353,8 @@ EventEmitter.prototype.removeListener =
       return this;
     };
 
+EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
+
 EventEmitter.prototype.removeAllListeners =
     function removeAllListeners(type) {
       var listeners, events;


### PR DESCRIPTION
As in https://nodejs.org/api/events.html#emitteroffeventname-listener,
add support for the `off` method to have a better/more complete
support of the `events` module.