### PR TITLE
fix: bad event polifilly

### DIFF
--- a/polyfills/events.js
+++ b/polyfills/events.js
@@ -12,7 +12,7 @@ function EventEmitter() {
   EventEmitter.init.call(this);
 }
 export default EventEmitter;
-export {EventEmitter};
+export EventEmitter;
 
 // nodejs oddity
 // require('events') === require('events').EventEmitter

--- a/polyfills/events.js
+++ b/polyfills/events.js
@@ -8,11 +8,10 @@ var domain;
 function EventHandlers() {}
 EventHandlers.prototype = Object.create(null);
 
-function EventEmitter() {
+export function EventEmitter() {
   EventEmitter.init.call(this);
 }
 export default EventEmitter;
-export EventEmitter;
 
 // nodejs oddity
 // require('events') === require('events').EventEmitter

--- a/polyfills/events.js
+++ b/polyfills/events.js
@@ -8,9 +8,12 @@ var domain;
 function EventHandlers() {}
 EventHandlers.prototype = Object.create(null);
 
-module.exports = function EventEmitter() {
+export function EventEmitter() {
   EventEmitter.init.call(this);
 }
+
+module.exports = EventEmitter
+
 export default EventEmitter;
 
 // nodejs oddity

--- a/polyfills/events.js
+++ b/polyfills/events.js
@@ -12,8 +12,6 @@ export function EventEmitter() {
   EventEmitter.init.call(this);
 }
 
-module.exports = EventEmitter
-
 export default EventEmitter;
 
 // nodejs oddity

--- a/polyfills/events.js
+++ b/polyfills/events.js
@@ -8,7 +8,7 @@ var domain;
 function EventHandlers() {}
 EventHandlers.prototype = Object.create(null);
 
-export function EventEmitter() {
+module.exports = function EventEmitter() {
   EventEmitter.init.call(this);
 }
 export default EventEmitter;


### PR DESCRIPTION
Fixes #16. This allows `const EventEmitter = require('events')` to work as intended