### PR TITLE
add events.setMaxListeners polyfill

### DIFF
--- a/polyfills/events.js
+++ b/polyfills/events.js
@@ -11,8 +11,29 @@ EventHandlers.prototype = Object.create(null);
 function EventEmitter() {
   EventEmitter.init.call(this);
 }
+
+function setMaxListeners(n, ...eventTargets) {
+  if (typeof n !== 'number' || n < 0 || isNaN(n))
+    throw new TypeError('"n" argument must be a positive number');
+
+  if (eventTargets.length === 0) {
+    EventEmitter.defaultMaxListeners = n;
+  } else {
+    for (let i = 0; i < eventTargets.length; i++) {
+      const target = eventTargets[i];
+      if (typeof target.setMaxListeners === 'function') {
+        target.setMaxListeners(n);
+      } else {
+        throw new TypeError('"eventTargets" must be instances of "EventEmitter"');
+      }
+    }
+  }
+}
+
+EventEmitter.setMaxListeners = setMaxListeners
+
 export default EventEmitter;
-export {EventEmitter};
+export {EventEmitter, setMaxListeners};
 
 // nodejs oddity
 // require('events') === require('events').EventEmitter


### PR DESCRIPTION
This is the minimal addition needed to build `js-libp2p` with vite. It fixes this error:

```
relay:build: > vite build
relay:build:
relay:build: vite v4.3.5 building for production...
relay:build: transforming...
relay:build: Use of eval in "../../node_modules/.pnpm/@protobufjs+inquire@1.1.0/node_modules/@
protobufjs/inquire/index.js" is strongly discouraged as it poses security risks and may cause
issues with minification.
relay:build: ✓ 604 modules transformed.
relay:build: ✓ built in 3.43s
relay:build: "setMaxListeners" is not exported by "../../node_modules/.pnpm/rollup-plugin-node
-polyfills@0.2.1/node_modules/rollup-plugin-node-polyfills/polyfills/events.js", imported by "
../../node_modules/.pnpm/libp2p@0.45.0/node_modules/libp2p/dist/src/connection-manager/utils.j
s".
relay:build: file: /Users/zach/repos/decentralized/ipdm/node_modules/.pnpm/libp2p@0.45.0/node_
modules/libp2p/dist/src/connection-manager/utils.js:4:9
relay:build: 2: import { logger } from '@libp2p/logger';
relay:build: 3: import { anySignal } from 'any-signal';
relay:build: 4: import { setMaxListeners } from 'events';
relay:build:             ^
relay:build: 5: const log = logger('libp2p:connection-manager:utils');
relay:build: 6: /**
relay:build: error during build:
relay:build: RollupError: "setMaxListeners" is not exported by "../../node_modules/.pnpm/rollu
p-plugin-node-polyfills@0.2.1/node_modules/rollup-plugin-node-polyfills/polyfills/events.js",
imported by "../../node_modules/.pnpm/libp2p@0.45.0/node_modules/libp2p/dist/src/connection-ma
nager/utils.js".
...
```

I've published this fix to npm as `@zaach/rollup-plugin-node-polyfills` for now to get this demo working: https://github.com/zaach/js-libp2p-webrtc-private-to-private